### PR TITLE
Stop AutoAssess extracting excess data

### DIFF
--- a/CMEW/inc/autoassess.cylc
+++ b/CMEW/inc/autoassess.cylc
@@ -9,15 +9,17 @@
 {% set ref_label = find_ref_label("rose-suite.conf") %}
 {% set eval_label = find_eval_label("rose-suite.conf") %}
 
+[task parameters]
+    aa_dataset = {{ [ref_dataset, eval_dataset] | join(", ") }}
+
 [scheduling]
     [[graph]]
         R1 = """
             install_env_file
                 => install_autoassess
-                => retrieve_ref_data<autoassess_area> & retrieve_eval_data<autoassess_area>
-                retrieve_ref_data<autoassess_area> => index_ref_data<autoassess_area>
-                retrieve_eval_data<autoassess_area> => index_eval_data<autoassess_area>
-                index_ref_data<autoassess_area> & index_eval_data<autoassess_area> => run_area<autoassess_area>
+                => retrieve_data<autoassess_area><aa_dataset>
+                => index_data<autoassess_area><aa_dataset>
+                => run_area<autoassess_area>
                 => nac_plot<autoassess_area>
                 => html_page<autoassess_area>
         """
@@ -50,32 +52,18 @@
     [[install_autoassess]]
         inherit = AUTOASSESS, SITE_AA_INSTALL
 
-    [[retrieve_eval_data<autoassess_area>]]
+    [[retrieve_data<autoassess_area><aa_dataset>]]
         inherit = AUTOASSESS, SITE_AA_RETRIEVAL
         [[[environment]]]
             ROSE_TASK_APP = aa_retrieve_data
-            SUITE_ID = {{ eval_dataset }}
+            SUITE_ID = $CYLC_TASK_PARAM_aa_dataset
             AREA = $CYLC_TASK_PARAM_autoassess_area
 
-    [[retrieve_ref_data<autoassess_area>]]
-        inherit = AUTOASSESS, SITE_AA_RETRIEVAL
-        [[[environment]]]
-            ROSE_TASK_APP = aa_retrieve_data
-            SUITE_ID = {{ ref_dataset }}
-            AREA = $CYLC_TASK_PARAM_autoassess_area
-
-    [[index_eval_data<autoassess_area>]]
+    [[index_data<autoassess_area><aa_dataset>]]
         inherit = AUTOASSESS, SITE_AA_DATA_INDEXING
         [[[environment]]]
             ROSE_TASK_APP = aa_index_data
-            SUITE_ID = {{ eval_dataset }}
-            AREA = $CYLC_TASK_PARAM_autoassess_area
-
-    [[index_ref_data<autoassess_area>]]
-        inherit = AUTOASSESS, SITE_AA_DATA_INDEXING
-        [[[environment]]]
-            ROSE_TASK_APP = aa_index_data
-            SUITE_ID = {{ ref_dataset }}
+            SUITE_ID = $CYLC_TASK_PARAM_aa_dataset
             AREA = $CYLC_TASK_PARAM_autoassess_area
 
     [[run_area<autoassess_area>]]

--- a/CMEW/inc/autoassess.cylc
+++ b/CMEW/inc/autoassess.cylc
@@ -14,9 +14,10 @@
         R1 = """
             install_env_file
                 => install_autoassess
-                => retrieve_data<autoassess_area><dataset>
-                => index_data<autoassess_area><dataset>
-                => run_area<autoassess_area>
+                => retrieve_ref_data<autoassess_area> & retrieve_eval_data<autoassess_area>
+                retrieve_ref_data<autoassess_area> => index_ref_data<autoassess_area>
+                retrieve_eval_data<autoassess_area> => index_eval_data<autoassess_area>
+                index_ref_data<autoassess_area> & index_eval_data<autoassess_area> => run_area<autoassess_area>
                 => nac_plot<autoassess_area>
                 => html_page<autoassess_area>
         """
@@ -49,18 +50,32 @@
     [[install_autoassess]]
         inherit = AUTOASSESS, SITE_AA_INSTALL
 
-    [[retrieve_data<autoassess_area><dataset>]]
+    [[retrieve_eval_data<autoassess_area>]]
         inherit = AUTOASSESS, SITE_AA_RETRIEVAL
         [[[environment]]]
             ROSE_TASK_APP = aa_retrieve_data
-            SUITE_ID = $CYLC_TASK_PARAM_dataset
+            SUITE_ID = {{ eval_dataset }}
             AREA = $CYLC_TASK_PARAM_autoassess_area
 
-    [[index_data<autoassess_area><dataset>]]
+    [[retrieve_ref_data<autoassess_area>]]
+        inherit = AUTOASSESS, SITE_AA_RETRIEVAL
+        [[[environment]]]
+            ROSE_TASK_APP = aa_retrieve_data
+            SUITE_ID = {{ ref_dataset }}
+            AREA = $CYLC_TASK_PARAM_autoassess_area
+
+    [[index_eval_data<autoassess_area>]]
         inherit = AUTOASSESS, SITE_AA_DATA_INDEXING
         [[[environment]]]
             ROSE_TASK_APP = aa_index_data
-            SUITE_ID = $CYLC_TASK_PARAM_dataset
+            SUITE_ID = {{ eval_dataset }}
+            AREA = $CYLC_TASK_PARAM_autoassess_area
+
+    [[index_ref_data<autoassess_area>]]
+        inherit = AUTOASSESS, SITE_AA_DATA_INDEXING
+        [[[environment]]]
+            ROSE_TASK_APP = aa_index_data
+            SUITE_ID = {{ ref_dataset }}
             AREA = $CYLC_TASK_PARAM_autoassess_area
 
     [[run_area<autoassess_area>]]


### PR DESCRIPTION
[(C) Crown Copyright 2023-2026, Met Office.]: #
[The LICENSE.md file contains full licensing details.]: #
Closes #474

## PR creation checklist for the _developer_

- [x] The `<issue_number>` above :point_up: has been replaced with the issue number.
- [x] `main` has been selected as the base branch.
- [x] The feature branch name follows the format `<issue_number>_<short_description_of_feature>`.
- [x] The text of the PR title exactly matches with the text (not including the issue number) of the issue title.
- [ ] Appropriate reviewers have been added to the PR (once it is ready for review).
- [x] The PR has been assigned to the developer(s).
- [x] The same labels as on the issue (except for the `good first issue` label) have been added to the PR.
- [x] The `Climate Model Evaluation Workflow (CMEW)` project has been added to the PR.
- [ ] The appropriate milestone has been added to the PR.

## Definition of Done for the _developer_

- [x] This PR contains **only** the changes needed to meet **all** acceptance criteria.
- [x] The change in this PR follows the requirements in the [wiki: Developer Guide](https://github.com/MetOffice/CMEW/wiki/Developer-Guide) (including copyrights).
- [x] The GitHub Actions workflow checks pass.
- [x] The tests run locally and pass (Note: the tests are not run by the GitHub Actions workflow, see [wiki: Run the tests locally](https://github.com/MetOffice/CMEW/wiki/Detailed-Working-Practices#run-the-tests-locally)).
- Updating the Rose metadata (select one of the following):
  - [ ] Rose metadata related to the change has been added or updated.
  - [x] The change does not require Rose metadata to be added or updated.
- Rendering the Rose metadata (select one of the following):
  - [ ] The Rose GUI shows the change as expected.
  - [x] The change in this PR does not affect the Rose GUI.
- Updating the tests (select one of the following):
  - [ ] Tests related to the change have been added or updated.
  - [x] The change does not require tests to be added or updated.
- Updating the user documentation (i.e. everything in the `doc` directory, including the [Quick Start](https://github.com/MetOffice/CMEW/blob/main/doc/source/user_guide/quick_start.rst) section; select one of the following):
  - [ ] The user documentation related to the change has been updated appropriately.
  - [x] The change in this PR does not require the user documentation to be updated.
- Rendering the user documentation ([wiki: Build the documentation locally](https://github.com/MetOffice/CMEW/wiki/Detailed-Working-Practices#build-the-documentation-locally) provides instructions; select one of the following):
  - [ ] The HTML pages show the change as expected.
  - [x] The change in this PR does not affect the HTML pages.
- Updating the API documentation (e.g. docstrings in Python modules; select one of the following):
  - [ ] The API documentation related to the change has been updated appropriately.
  - [x] The change in this PR does not affect the API documentation.

Copyright and IPR:
| | GitHub handles |
|---|---|
| I confirm that all code is my own and that my contributions are not subject to copyright or license restrictions. | NParsonsMO |
| I confirm I have not knowingly violated intellectual property rights (IPR) and have taken [sensible measures to prevent doing so](https://github.com/MetOffice/CMEW/wiki/Detailed-Working-Practices#coding-requirements), including appropriate [attribution for usage of Generative AI](https://github.com/MetOffice/CMEW/wiki/Detailed-Working-Practices#modify-the-code). I confirm that this work is my own, and I understand that it is my responsibility to ensure I am not violating others’ IPR.  This includes taking reasonable steps to ensure that all tools used while creating this contribution did not infringe IPR. | NParsonsMO |


## PR creation checklist for the _reviewer_

- [x] The `<issue_number>` above :point_up: has been replaced with the issue number.
- [x] `main` has been selected as the base branch.
- [x] The feature branch name follows the format `<issue_number>_<short_description_of_feature>`.
- [x] The text of the PR title exactly matches with the text (not including the issue number) of the issue title.
- [x] Appropriate reviewers have been added to the PR (once it is ready for review).
- [x] The PR has been assigned to the developer(s).
- [x] The same labels as on the issue (except for the `good first issue` label) have been added to the PR.
- [x] The `Climate Model Evaluation Workflow (CMEW)` project has been added to the PR.
- [x] The appropriate milestone has been added to the PR.

## Definition of Done for the _reviewer_

- [x] This PR contains **only** the changes needed to meet **all** acceptance criteria.
- [x] The change in this PR follows the requirements in the [wiki: Developer Guide](https://github.com/MetOffice/CMEW/wiki/Developer-Guide) (including copyrights).
- [x] All developers of this PR have added their names to the Copyright and IPR statements above.
- [x] The GitHub Actions workflow checks pass.
- [x] The tests run locally and pass (Note: the tests are not run by the GitHub Actions workflow, see [wiki: Run the tests locally](https://github.com/MetOffice/CMEW/wiki/Detailed-Working-Practices#run-the-tests-locally)).
- Updating the Rose metadata (select one of the following):
  - [ ] Rose metadata related to the change has been added or updated.
  - [x] The change does not require Rose metadata to be added or updated.
- Rendering the Rose metadata (select one of the following):
  - [ ] The Rose GUI shows the change as expected.
  - [x] The change in this PR does not affect the Rose GUI.
- Updating the tests (select one of the following):
  - [ ] Tests related to the change have been added or updated.
  - [x] The change does not require tests to be added or updated.
- Updating the user documentation (i.e. everything in the `doc` directory, including the [Quick Start](https://github.com/MetOffice/CMEW/blob/main/doc/source/user_guide/quick_start.rst) section; select one of the following):
  - [ ] The user documentation related to the change has been updated appropriately.
  - [x] The change in this PR does not require the user documentation to be updated.
- Rendering the user documentation ([wiki: Build the documentation locally](https://github.com/MetOffice/CMEW/wiki/Detailed-Working-Practices#build-the-documentation-locally) provides instructions; select one of the following):
  - [ ] The HTML pages show the change as expected.
  - [x] The change in this PR does not affect the HTML pages.
- Updating the API documentation (e.g. docstrings in Python modules; select one of the following):
  - [ ] The API documentation related to the change has been updated appropriately.
  - [x] The change in this PR does not affect the API documentation.

> [!IMPORTANT]
> - Remember to re-check the Definition of Done after making changes in response to a review.
> - The developer merges the PR.
> - Remember to use the format `#<pull_request_number>: <pull_request_title>` when writing the merge commit message for the pull request, so the pull request number is immediately visible on GitHub, regardless of the length of the pull request title.
